### PR TITLE
chore: move standard-version to root

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -7,6 +7,10 @@
   ],
   "bumpFiles": [
     {
+      "filename": "./plugin/package.json",
+      "type": "json"
+    },
+    {
       "filename": "./example/package.json",
       "type": "json"
     }

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,14 @@
+{
+  "packageFiles": [
+    {
+      "filename": "./plugin/package.json",
+      "type": "json"
+    }
+  ],
+  "bumpFiles": [
+    {
+      "filename": "./example/package.json",
+      "type": "json"
+    }
+  ]
+}

--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "lint:md": "markdownlint README.md",
     "start": "craco start"
   },
+  "homepage": "./",
   "dependencies": {
     "@craco/craco": "^5.6.4",
     "@testing-library/jest-dom": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "private": true,
+  "scripts": {
+    "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'main' ] && standard-version --no-verify"
+  },
   "workspaces": {
     "packages": [
       "example",
@@ -12,6 +15,7 @@
     ]
   },
   "devDependencies": {
-    "husky": "4.2.5"
+    "husky": "4.2.5",
+    "standard-version": "8.0.2"
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -22,7 +22,6 @@
     "lint:md": "markdownlint README.md src/**/*.md",
     "prepare": "yarn build",
     "prepublishOnly": "cp ../README.md ./",
-    "tag": "[ `git rev-parse --abbrev-ref HEAD` = 'main' ] && standard-version --no-verify",
     "test": "jest",
     "test:ci": "prettier-package-json --list-different && yarn format:all --check && yarn lint && yarn test"
   },
@@ -65,7 +64,6 @@
     "rollup-plugin-delete": "2.0.0",
     "rollup-plugin-node-polyfills": "0.2.1",
     "rollup-plugin-typescript2": "0.27.1",
-    "standard-version": "8.0.2",
     "tailwindcss": "1.4.6",
     "ts-jest": "26.1.0",
     "tslib": "2.0.0",


### PR DESCRIPTION
## Description

In preparation for the first release, I need to update the configuration for `standard-version`. With us moving to yarn workspaces I've:

- Moved the standard-version and `yarn run tag` call to the root of the repository
- Configured standard-version to only read and bump the `./plugin/package.json` file
- Configured standard-version to bump the `./example/package.json` file
