### PR TITLE
fix(build): allow standard-version deployments to update all yarn workspaces

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -9,6 +9,10 @@
     {
       "filename": "./plugin/package.json",
       "type": "json"
+    },
+    {
+      "filename": "./example/package.json",
+      "updater": "utils/example-package-updater.js"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     ]
   },
   "devDependencies": {
+    "detect-indent": "6.0.0",
+    "detect-newline": "3.1.0",
     "husky": "4.2.5",
-    "standard-version": "8.0.2"
+    "standard-version": "8.0.2",
+    "stringify-package": "1.0.1"
   }
 }

--- a/utils/example-package-updater.js
+++ b/utils/example-package-updater.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const stringifyPackage = require('stringify-package');
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+
+module.exports.readVersion = function (contents) {
+  return JSON.parse(contents).dependencies['@zendeskgarden/tailwindcss'];
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const json = JSON.parse(contents);
+  const indent = detectIndent(contents).indent;
+  const newline = detectNewline(contents);
+
+  json.dependencies['@zendeskgarden/tailwindcss'] = version;
+
+  return stringifyPackage(json, indent, newline);
+};
+
+module.exports.isPrivate = function (contents) {
+  return JSON.parse(contents).private;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5090,20 +5090,20 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-detect-indent@^6.0.0:
+detect-indent@6.0.0, detect-indent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
   integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
+
+detect-newline@3.1.0, detect-newline@^3.0.0, detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 detect-newline@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
-
-detect-newline@^3.0.0, detect-newline@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
-  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -13504,7 +13504,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-stringify-package@^1.0.1:
+stringify-package@1.0.1, stringify-package@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==


### PR DESCRIPTION
## Description

While trying to release v1 I ran into some issues with `yarn workspaces` and `standard-version` not understanding correct version ranges.

I've create a custom `bumpFiles` updater for `standard-version` to update the `example/package.json` file whenever a release is created.