### PR TITLE
fix: ensure preflight styles are removed when Garden bedrock is applied

### DIFF
--- a/example/src/components/Message/index.tsx
+++ b/example/src/components/Message/index.tsx
@@ -29,4 +29,4 @@ export const Message: React.FC<{ actions?: React.ReactElement }> = ({ children, 
 export const Action: React.FC<ButtonHTMLAttributes<HTMLButtonElement>> = ({
   className,
   ...other
-}) => <button className={classNames(className, styles.action)} {...other} />;
+}) => <button className={classNames(className, styles.action)} type="button" {...other} />;

--- a/example/src/components/Message/message.module.css
+++ b/example/src/components/Message/message.module.css
@@ -26,6 +26,7 @@
 }
 
 .action {
+  border: 0 solid;
   @apply block;
   @apply w-full;
   @apply bg-white;

--- a/plugin/src/__snapshots__/index.spec.ts.snap
+++ b/plugin/src/__snapshots__/index.spec.ts.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Garden TailwindCSS Plugin Bedrock reset applies preflight styles when disabled 1`] = `""`;
-
-exports[`Garden TailwindCSS Plugin Bedrock reset is applied by default 1`] = `
+exports[`Garden TailwindCSS Plugin Bedrock reset applies preflight styles when disabled 1`] = `
 "/*! normalize.css v8.0.1 | MIT License | github.com/necolas/normalize.css */
 
 /* Document
@@ -580,9 +578,11 @@ img,
 video {
   max-width: 100%;
   height: auto;
-}
+}"
+`;
 
-/*!
+exports[`Garden TailwindCSS Plugin Bedrock reset is applied by default 1`] = `
+"/*!
  * Copyright Zendesk, Inc.
  *
  * Use of this source code is governed under the Apache License, Version 2.0

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -35,7 +35,7 @@ export default plugin.withOptions(
   (options: IPluginOptions = DEFAULT_OPTIONS) => ({
     theme: gardenTheme, // Overwrite global theme with Garden values
     corePlugins: {
-      preflight: !!options.includeBedrock // Disable Tailwind global resets as we provide our own
+      preflight: !options.includeBedrock // Disable Tailwind global resets as we provide our own
     }
   })
 ) as (options?: IPluginOptions) => void;


### PR DESCRIPTION
## Description

In our tailwindcss logic we were including tailwind preflight styles in combination with Garden bedrock. This logic has been negated.