### PR TITLE
fix: restore styles.css package dist

### DIFF
--- a/plugin/tailwind.config.js
+++ b/plugin/tailwind.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  plugins: [require('./dist/index')]
+  plugins: [require('./dist/index')],
+  safelist: [{ pattern: /.*/ }]
 };


### PR DESCRIPTION
## Description

The move from tailwindcss v2.0 to 3.0 replaced the purgecss mechanism with a new [JIT engine](https://tailwindcss.com/docs/upgrade-guide#migrating-to-the-jit-engine) that is the default. For Garden's plugin, this means we need to [safelist](https://tailwindcss.com/docs/content-configuration#safelisting-classes) all classes in order to build a valid package `styles` dist. Otherwise, tailwind attempts to use the `content` configuration to perform [class detection](https://tailwindcss.com/docs/content-configuration#class-detection-in-depth), and in this case finds none.

## Detail

`@zendeskgarden/tailwindcss` v2.0.0 dist (large)

https://unpkg.com/browse/@zendeskgarden/tailwindcss@2.0.0/dist/styles.css

`@zendeskgarden/tailwindcss` v3.0.0 dist (empty)

https://unpkg.com/browse/@zendeskgarden/tailwindcss@3.0.0/dist/styles.css
