### PR TITLE
chore: fix CI publish

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -13,9 +13,13 @@
     {
       "filename": "./example/package.json",
       "updater": "utils/example-package-updater.js"
+    },
+    {
+      "filename": "./package-lock.json",
+      "type": "json"
     }
   ],
   "scripts": {
-    "precommit": "npm install"
+    "postbump": "npm install"
   }
 }

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -14,5 +14,8 @@
       "filename": "./example/package.json",
       "updater": "utils/example-package-updater.js"
     }
-  ]
+  ],
+  "scripts": {
+    "precommit": "npm install"
+  }
 }

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -18,8 +18,5 @@
       "filename": "./package-lock.json",
       "type": "json"
     }
-  ],
-  "scripts": {
-    "postbump": "npm install"
-  }
+  ]
 }

--- a/example/package.json
+++ b/example/package.json
@@ -30,7 +30,7 @@
     "@zendeskgarden/eslint-config": "43.0.0",
     "@zendeskgarden/scripts": "2.4.1",
     "@zendeskgarden/svg-icons": "7.3.0",
-    "@zendeskgarden/tailwindcss": "4.0.0",
+    "@zendeskgarden/tailwindcss": "4.0.1",
     "autoprefixer": "10.4.20",
     "envalid": "8.0.0",
     "eslint": "9.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@zendeskgarden/react-forms": "9.0.0",
         "@zendeskgarden/react-theming": "9.0.0",
         "@zendeskgarden/react-typography": "9.0.0",
-        "@zendeskgarden/tailwindcss": "4.0.0",
+        "@zendeskgarden/tailwindcss": "4.0.1",
         "classnames": "2.5.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -38,7 +38,7 @@
         "@zendeskgarden/eslint-config": "43.0.0",
         "@zendeskgarden/scripts": "2.4.1",
         "@zendeskgarden/svg-icons": "7.3.0",
-        "@zendeskgarden/tailwindcss": "4.0.0",
+        "@zendeskgarden/tailwindcss": "4.0.1",
         "autoprefixer": "10.4.20",
         "envalid": "8.0.0",
         "eslint": "9.9.0",
@@ -34533,7 +34533,7 @@
     },
     "plugin": {
       "name": "@zendeskgarden/tailwindcss",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@zendeskgarden/css-bedrock": "^9.0.0",

--- a/utils/example-package-updater.js
+++ b/utils/example-package-updater.js
@@ -19,6 +19,7 @@ module.exports.writeVersion = function (contents, version) {
   const newline = detectNewline(contents);
 
   json.dependencies['@zendeskgarden/tailwindcss'] = version;
+  json.devDependencies['@zendeskgarden/tailwindcss'] = version;
 
   return stringifyPackage(json, indent, newline);
 };


### PR DESCRIPTION
## Description

Since updating from `yarn` to `npm`, tag builds have been [failing](https://app.circleci.com/pipelines/github/zendeskgarden/tailwindcss/1728/workflows/9d2b2043-5f84-42dd-9cba-08e2f963b125/jobs/3067). This update ensures files are in sync after `npm run tag` and the build won't fail during `npm ci`.
